### PR TITLE
init: headless lib directory

### DIFF
--- a/dioxycomp-headless/Cargo.toml
+++ b/dioxycomp-headless/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "dioxycomp-headless"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/dioxycomp-headless/src/lib.rs
+++ b/dioxycomp-headless/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
This is the initial directory of the headless lib

Closes #1