### PR TITLE
feature: select component

### DIFF
--- a/dioxycomp-headless/Cargo.lock
+++ b/dioxycomp-headless/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "dioxycomp-headless"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "dioxus",
 ]

--- a/dioxycomp-headless/Cargo.toml
+++ b/dioxycomp-headless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxycomp-headless"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dioxycomp-headless/src/components.rs
+++ b/dioxycomp-headless/src/components.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+pub mod Button;
 pub mod Checkbox;
 pub mod Radio;
-pub mod SimpleButton;
+pub mod Select;

--- a/dioxycomp-headless/src/components/Button.rs
+++ b/dioxycomp-headless/src/components/Button.rs
@@ -1,15 +1,15 @@
-//! # Simple Button Component
+//! # Button Component
 //!
 //! Renders a simple button which can be clicked to toggle
 
 #![allow(non_snake_case)]
 use dioxus::prelude::*;
 
-pub fn SimpleButton(cx: Scope) -> Element {
+pub fn Button(cx: Scope) -> Element {
     let state = use_state(&cx, || false);
 
     cx.render(rsx!(button {
-        style: "width:4em; height:2em; font-size: 2em; border:1px solid #fef",
+        style: "width:3em; height:2em; font-size: 1em; border:1px solid #fef",
         onclick: move |_| state.set(!state),
         "OK",
     }))

--- a/dioxycomp-headless/src/components/Checkbox.rs
+++ b/dioxycomp-headless/src/components/Checkbox.rs
@@ -9,8 +9,8 @@ pub fn Checkbox(cx: Scope) -> Element {
     let state = use_state(&cx, || false);
 
     cx.render(rsx!(input {
-      "type": "checkbox",
-      style: "width:1em; height:1em;",
-      onclick: move |_| state.set(!state),
+        r#type: "checkbox",
+        style: "width:1em; height:1em;",
+        onclick: move |_| state.set(!state),
     }))
 }

--- a/dioxycomp-headless/src/components/Select.rs
+++ b/dioxycomp-headless/src/components/Select.rs
@@ -1,0 +1,29 @@
+//! # Select Component
+//!
+//! Renders a Select component which can be clicked to select option from a list
+
+#![allow(non_snake_case)]
+
+use dioxus::prelude::*;
+
+pub fn Select(cx: Scope) -> Element {
+    let state = use_state(&cx, || (0, ""));
+
+    cx.render(rsx!(
+      select {
+        style: "width: 9rem; height: 2rem; padding-left: 1rem; background-color: #404040;",
+        onchange: move |_| state.set((0,"option 1")),
+        option {
+          id: 0,
+          "option 1"
+        },
+        option {
+          id: 1,
+          "option 2"
+        },
+        option {
+          id: 2,
+          "option 3"
+        }
+    }))
+}

--- a/examples/web-hydrated/Cargo.lock
+++ b/examples/web-hydrated/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "dioxycomp-headless"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "dioxus",
 ]

--- a/examples/web-hydrated/src/pages/headless/components.rs
+++ b/examples/web-hydrated/src/pages/headless/components.rs
@@ -2,4 +2,5 @@
 pub mod ButtonPage;
 pub mod CheckboxPage;
 pub mod RadioPage;
+pub mod SelectPage;
 pub mod SideBarNav;

--- a/examples/web-hydrated/src/pages/headless/components/ButtonPage.rs
+++ b/examples/web-hydrated/src/pages/headless/components/ButtonPage.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use dioxus::prelude::*;
-use dioxycomp_headless::components::SimpleButton::SimpleButton;
+use dioxycomp_headless::components::Button::Button;
 
 #[inline_props]
 pub fn ButtonPage(cx: Scope, name: String) -> Element {
@@ -11,7 +11,7 @@ pub fn ButtonPage(cx: Scope, name: String) -> Element {
 
         },
         p {
-            SimpleButton {}
+            Button {}
         }
 
     })

--- a/examples/web-hydrated/src/pages/headless/components/SelectPage.rs
+++ b/examples/web-hydrated/src/pages/headless/components/SelectPage.rs
@@ -1,0 +1,18 @@
+#![allow(non_snake_case)]
+
+use dioxus::prelude::*;
+use dioxycomp_headless::components::Select::Select;
+
+#[inline_props]
+pub fn SelectPage(cx: Scope, name: String) -> Element {
+    cx.render(rsx! {
+        h1 {
+        "This is a select page"
+
+        },
+        p {
+            Select {}
+        }
+
+    })
+}

--- a/examples/web-hydrated/src/pages/headless/components/SideBarNav.rs
+++ b/examples/web-hydrated/src/pages/headless/components/SideBarNav.rs
@@ -9,13 +9,14 @@ use crate::router::PageRouter::Route;
 pub fn SideBarNav(cx: Scope) -> Element {
     let nav_style = "fixed p-4 w-full h-2/6 bg-zinc-900 lg:w-72 lg:h-full";
     let li_style = "flex-none pl-4 py-2 hover:bg-neutral-600 hover:rounded-md hover:duration-100";
+
     cx.render(rsx! {
-              nav {
-              id: "sidebar",
-              class: "{nav_style}",
-              details {
-              class: "group",
-              open: "true",
+      nav {
+            id: "sidebar",
+            class: "{nav_style}",
+            details {
+            class: "group",
+            open: "true",
                       summary {
                             class: "p-3 w-64 h-12 bg-zinc-800 rounded-xl group-open:rounded-b-none font-semibold",
                             "Components",
@@ -46,6 +47,14 @@ pub fn SideBarNav(cx: Scope) -> Element {
                                           class: "{li_style}",
                                         "Radio"
                                           }
+                                    },
+                                    Link {
+                                        class: " ",
+                                        to: Route::PageLoader { name: String::from("Select")},
+                                    li {
+                                          class: "{li_style}",
+                                        "Select"
+                                    }
                             },
                       }
                 }

--- a/examples/web-hydrated/src/router/PageLoader.rs
+++ b/examples/web-hydrated/src/router/PageLoader.rs
@@ -6,6 +6,7 @@ use dioxus_router::prelude::*;
 use crate::pages::headless::components::ButtonPage::ButtonPage;
 use crate::pages::headless::components::CheckboxPage::CheckboxPage;
 use crate::pages::headless::components::RadioPage::RadioPage;
+use crate::pages::headless::components::SelectPage::SelectPage;
 
 #[inline_props]
 pub fn PageLoader(cx: Scope, name: String) -> Element {
@@ -21,6 +22,10 @@ pub fn PageLoader(cx: Scope, name: String) -> Element {
         "Radio" => cx.render(rsx! {
             p { "{name}"},
             RadioPage { name: String::from("Radio")}
+        }),
+        "Select" => cx.render(rsx! {
+            p { "{name}"},
+            SelectPage { name: String::from("Select")}
         }),
         _ => cx.render(rsx! {
             p { "no page to render" }

--- a/examples/web/Cargo.lock
+++ b/examples/web/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "dioxycomp-headless"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "dioxus",
 ]


### PR DESCRIPTION
Add Select component to Examples and Headless
Fix headless version
Rename "SimpleButton" component to just "Button"
Use literal for the type attribute in Checkbox component

Closes #12, closes #56