### PR TITLE
ci: wrong working dir path

### DIFF
--- a/.github/workflows/generate-pages.yml
+++ b/.github/workflows/generate-pages.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install deps
-        working-directory: ./web-hydrated
+        working-directory: ./examples/web-hydrated
         run: cargo install dioxus-cli --force
 
       - name: Build Public Pages
-        working-directory: ./web-hydrated
+        working-directory: ./examples/web-hydrated
         run: rm -rf ./docs
           npx tailwindcss -i ./public/tailwind_input.css -o ./public/css/tailwind.css
           dx build --features web --release


### PR DESCRIPTION
Fix wrong working-directory path in generate-pages workflow