### PR TITLE
refactor: label component

### DIFF
--- a/dioxycomp-headless/src/components/Label.rs
+++ b/dioxycomp-headless/src/components/Label.rs
@@ -4,29 +4,35 @@
 
 #![allow(non_snake_case)]
 #![allow(unused)]
-use dioxus::{html::GlobalAttributes, prelude::*};
+use dioxus::{html::label, prelude::*};
 
 #[derive(Props, Clone, Default)]
 pub struct LabelProps<'a> {
     pub id: Option<&'a str>,
     pub r#for: Option<&'a str>,
     pub value: Option<&'a str>,
-    pub className: Option<&'a str>,
+    pub class_name: Option<&'a str>,
     pub styles: Option<&'a str>,
 }
 #[derive(Props, Clone, Default)]
 pub struct AllLabelProps<'a> {
-    pub label_props: LabelProps<'a>,
+    #[props(!optional)]
+    pub label_props: Option<LabelProps<'a>>,
+    pub r#for: Option<&'a str>,
+    pub children: Element<'a>,
 }
 
 pub fn Label<'a>(cx: Scope<'a, AllLabelProps<'a>>) -> Element<'a> {
-    cx.render(rsx! {
-        label{
-            id: cx.props.label_props.id,
-            r#for: cx.props.label_props.r#for,
-            class: cx. props.label_props.className,
-            style: cx.props.label_props.styles,
-        },
-        cx.props.label_props.value
-    })
+    match cx.props.label_props {
+        Some(_) => cx.render(rsx! {
+            label {
+                id: cx.props.label_props.as_ref().and_then(|lp| lp.id),
+                r#for: cx.props.label_props.as_ref().and_then(|lp| lp.r#for),
+                class: cx.props.label_props.as_ref().and_then(|lp| lp.class_name),
+                style: cx.props.label_props.as_ref().and_then(|lp| lp.styles),
+                cx.props.label_props.as_ref().and_then(|lp| lp.value)
+            },
+        }),
+        None => cx.render(rsx! { label { cx.props.children.as_ref().unwrap() } }),
+    }
 }

--- a/dioxycomp-headless/src/components/Label.rs
+++ b/dioxycomp-headless/src/components/Label.rs
@@ -4,7 +4,7 @@
 
 #![allow(non_snake_case)]
 #![allow(unused)]
-use dioxus::{html::label, prelude::*};
+use dioxus::prelude::*;
 
 #[derive(Props, Clone, Default)]
 pub struct LabelProps<'a> {


### PR DESCRIPTION
Add missing prop for the CSS class support
Props for the internal Label component are optional now
Internal label component is rendered depending on props provided or not

Closes #88