### PR TITLE
fix: components props passing

### DIFF
--- a/dioxycomp-headless/src/components/Button.rs
+++ b/dioxycomp-headless/src/components/Button.rs
@@ -5,32 +5,33 @@
 #![allow(non_snake_case)]
 #![allow(unused)]
 use dioxus::prelude::*;
+use dioxus_elements::button;
 
-#[derive(PartialEq, Props, Clone)]
-pub struct ButtonProps {
-    pub id: Option<String>,
-    pub label: Option<String>,
-    pub autofocus: Option<bool>,
-    pub disabled: Option<bool>,
-    pub name: Option<String>,
-    pub r#type: Option<String>,
-    pub value: Option<String>,
-    pub styles: Option<String>,
-}
-
-pub fn Button(button_props: ButtonProps) -> Element {
+#[component]
+pub fn Button(
+    onpress: EventHandler<MouseEvent>,
+    children: Element,
+    id: Option<String>,
+    styles: Option<String>,
+    name: Option<String>,
+    value: Option<String>,
+    disabled: Option<bool>,
+    r#type: Option<String>,
+    autofocus: Option<bool>,
+) -> Element {
     let mut state = use_signal(|| false);
+    let setState = |mut st: Signal<bool>| st.toggle();
     rsx! {
         button {
-            id: button_props.id,
-            autofocus:  button_props.autofocus,
-            disabled:  button_props.disabled,
-            name:  button_props.name,
-            r#type:  button_props.r#type,
-            value: button_props.value,
-            style:  button_props.styles,
-            onclick: move |_| state.toggle(),
-            "{button_props.label.unwrap()}"
+                id: id,
+                autofocus: autofocus,
+                disabled: disabled,
+                name: name,
+                r#type: r#type,
+                value: value,
+                style: styles,
+                onclick: move |event| onpress.call(event),
+                {children}
         }
     }
 }

--- a/dioxycomp-headless/src/components/Checkbox.rs
+++ b/dioxycomp-headless/src/components/Checkbox.rs
@@ -5,20 +5,18 @@
 #![allow(non_snake_case)]
 use dioxus::prelude::*;
 
-pub fn Checkbox() -> Element {
-    let mut state = use_signal(|| false);
-
-    rsx!(
-        input {
-            r#type: "checkbox",
-            name: "checkbox",
-            style: "width:1em; height:1em;",
-            onclick: move |_| state.toggle() ,
-        },
-        label{
-            style: "padding-left: 1rem",
-            r#for: "checkbox",
-            "Check me"
-        },
-    )
+#[component]
+pub fn Checkbox(
+    onpress: EventHandler<MouseEvent>,
+    name: Option<String>,
+    class_name: Option<String>,
+    styles: Option<String>,
+) -> Element {
+    rsx!(input {
+        r#type: "checkbox",
+        name: name,
+        class: class_name,
+        style: styles,
+        onclick: move |event| onpress.call(event),
+    },)
 }

--- a/dioxycomp-headless/src/components/Radio.rs
+++ b/dioxycomp-headless/src/components/Radio.rs
@@ -5,20 +5,20 @@
 #![allow(non_snake_case)]
 use dioxus::prelude::*;
 
-pub fn Radio() -> Element {
-    let mut state = use_signal(|| false);
-
-    rsx!(
-      input {
-        r#type: "radio",
-        id: "radio-n",
-        style: "width:1em; height:1em;",
-        onclick: move |_| state.toggle(),
-      }
-      label {
-        style: "padding-left: 1rem",
-        r#for: "radio-n",
-        "Selected"
-      }
-    )
+#[component]
+pub fn Radio(
+    onclick: EventHandler<MouseEvent>,
+    id: Option<String>,
+    class_name: Option<String>,
+    styles: Option<String>,
+) -> Element {
+    rsx! {
+        input {
+            r#type: "radio",
+            id: id,
+            class: class_name,
+            style: styles,
+            onclick: move |event| onclick.call(event),
+        }
+    }
 }

--- a/dioxycomp-headless/src/components/Select.rs
+++ b/dioxycomp-headless/src/components/Select.rs
@@ -6,28 +6,23 @@
 
 use dioxus::prelude::*;
 
-pub fn Select() -> Element {
-    let mut selected = use_signal(|| "option 1".to_string());
-    let styles: String =
-        String::from("width: 9rem; height: 2rem; padding-left: 1rem; background-color: #404040;");
+#[component]
+pub fn Select(
+    id: Option<String>,
+    value: String,
+    class_name: Option<String>,
+    styles: Option<String>,
+    children: Element,
+) -> Element {
+    let mut selected: Signal<String> = use_signal(|| value);
 
-    rsx!(
+    rsx! {
       select {
-        style: styles,
-        value: "{selected()}",
-        prevent_default: "onchange",
-        onchange: move |event| selected.set(event.value()),
-        option {
-          value: "option 2",
-          "option 1"
-        },
-        option {
-          value: "option 2",
-          "option 2"
-        },
-        option {
-          id: "option 3",
-          "option 3"
+            value: "{selected()}",
+            prevent_default: "onchange",
+            style: styles,
+            onchange: move |event| selected.set(event.value()),
+            {children}
         }
-    })
+    }
 }


### PR DESCRIPTION
All props are moved as corresponding function arguments 
Remove structs with props
" #[component] " macro is used so that the props can work, if they are used as arguments

Closes #92